### PR TITLE
remove the drawFace 3rd argument

### DIFF
--- a/3D/Basic3DType/Basic3DType.pde
+++ b/3D/Basic3DType/Basic3DType.pde
@@ -53,7 +53,7 @@ void draw() {
     // colors are stored in each Face's label (see colorFaces() method below)
     fill(face.getLabel());
     // draw the face using Hemesh's render class
-    render.drawFace(face, false, mesh);
+    render.drawFace(face, false);
   }
 }
 


### PR DESCRIPTION
I got an error while using the latest HE_Mesh2014 so I removed the argument:

```
Basic3DType.pde:56:0:56:0: The method drawFace(HE_Face, boolean) in the type WB_Render3D is not applicable for the arguments (HE_Face, boolean, HE_Mesh)
```
